### PR TITLE
Description must not contain newlines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,14 @@ setup(
     author='sv99',
     author_email='sv99@inbox.ru',
     url='https://github.com/sv99/lsdreader',
-    description='Linvo 11, 12, X3, X5 and X6 lsd reader Utilities\n compatible with python2.7 and python3',
+    description='Linvo 11, 12, X3, X5 and X6 lsd reader utilities',
     long_description=read('README.rst'),
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Topic :: Education',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+    ],
     packages=find_packages(),
     platforms='any',
     install_requires=[


### PR DESCRIPTION
Hello. During [packaging](https://aur.archlinux.org/packages/lsdreader) _lsdreader_ for Archlinux (python 3.10.2, setuptools 1:59.3.0) I faced with invalid 'description' field - it must not contain newlines or build fails. So I decided to move python compatibility declaration into 'classifiers' list.

Also please explicitly [choose license](https://choosealicense.com/) like MIT or GNU GPLv3 in _setup.py_ and [repo root](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository).